### PR TITLE
ENS-25: Change the password length requirements

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -9,8 +9,8 @@ class User < ApplicationRecord
   audited 
 
   def password_complexity
-    return if password.blank? || password =~ /^(?=.*[A-Za-z])(?=.*\d)(?=.*[$@$!%*#?&])[A-Za-z\d$@$!%*#?&]{8,}$/
+    return if password.blank? || password =~ /^(?=.*[A-Za-z])(?=.*\d)(?=.*[$@$!%*#?&])[A-Za-z\d$@$!%*#?&]{8,64}$/
 
-    errors.add :password, 'Password requirements not met, length should be minimum 8 charecters and include: 1 Uppercase, 1 Lowercase, 1 Digit and 1 special charecter'
+    errors.add :password, 'requirements not met, length should be 8-64 characters in length and include: 1 Uppercase, 1 Lowercase, 1 Digit and 1 special character'
   end
 end

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -163,7 +163,7 @@ Devise.setup do |config|
 
   # ==> Configuration for :validatable
   # Range for password length.
-  config.password_length = 6..128
+  config.password_length = 8..64
 
   # Email regex used to validate email formats. It simply asserts that
   # one (and only one) @ exists in the given string. This is mainly


### PR DESCRIPTION
1. Changed the password length requirements from minimum 8 characters to maximum of 64 characters, adhering to the NIST 800-63 Digital Authenticity Guidelines